### PR TITLE
{teme/tema, proiect1}: Sort input files

### DIFF
--- a/proiect1/src/Test.java
+++ b/proiect1/src/Test.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.*;
@@ -133,7 +134,9 @@ public final class Test {
         totalScore = config.getCheckstyleScore();
         int manualScore = config.getReadmeScore() + config.getHomeworkDesignScore();
 
-        for (final File testFile : Objects.requireNonNull(TEST_INPUTS_FILE.listFiles())) {
+        File[] files = Objects.requireNonNull(TEST_INPUTS_FILE.listFiles());
+        Arrays.sort(files);
+        for (final File testFile : files) {
             String testFileName = testFile.getName();
 
             preTestCleanUp();

--- a/teme/tema/src/main/Main.java
+++ b/teme/tema/src/main/Main.java
@@ -14,6 +14,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Objects;
+import java.util.Arrays;
 
 /**
  * The entry point to this homework. It runs the checker that tests your implentation.
@@ -44,7 +45,9 @@ public final class Main {
         }
         Files.createDirectories(path);
 
-        for (File file : Objects.requireNonNull(directory.listFiles())) {
+        File[] files = Objects.requireNonNull(directory.listFiles());
+        Arrays.sort(files);
+        for (File file : files) {
             String filepath = CheckerConstants.OUT_PATH + file.getName();
             File out = new File(filepath);
             boolean isCreated = out.createNewFile();


### PR DESCRIPTION
By default, running tests for OOP assignments looks something like this:

```console
[basic_5]: ..................... 6/6
[basic_10]: ..................... 6/6
[basic_3]: ..................... 6/6
[basic_8]: ..................... 6/6
[basic_2]: ..................... 6/6
[basic_7]: ..................... 6/6
[basic_6]: ..................... 6/6
[basic_9]: ..................... 6/6
[basic_1]: ..................... 6/6
[basic_4]: ..................... 6/6
-----------------------------------------------------
```
Obviously, input files don't get automatically sorted.

This PR sorts input files alphabetically in order to ensure that they are parsed in a consistent manner. It manages both the first assignment and the project.

Signed-off-by: Maria Sfiraiala <maria.sfiraiala@gmail.com>